### PR TITLE
[google_vm_with_r53_private_dns] Add new input: Service account scopes

### DIFF
--- a/google_vm_with_r53_private_dns/inputs.tf
+++ b/google_vm_with_r53_private_dns/inputs.tf
@@ -43,3 +43,8 @@ variable "google_deployer_ssh_public_key" {
   type    = "string"
   default = ""
 }
+
+variable "service_account_scopes" {
+  type    = "list"
+  default = []
+}

--- a/google_vm_with_r53_private_dns/main.tf
+++ b/google_vm_with_r53_private_dns/main.tf
@@ -22,6 +22,10 @@ resource "google_compute_instance" "vm" {
     host_group = "${var.host_group}"
     ssh-keys   = "${var.google_deployer_ssh_public_key}"
   }
+
+  service_account {
+    scopes = "${var.service_account_scopes}"
+  }
 }
 
 resource "aws_route53_record" "dns-int" {


### PR DESCRIPTION
Required in order to be able to inject the service acount scopes to a VM, so it can, for example, pull from the Docker registry.

WDYT @cabify/systems ?