### PR TITLE
Release 1.6 without scrappers

### DIFF
--- a/google-cloud/sql/main.tf
+++ b/google-cloud/sql/main.tf
@@ -57,13 +57,3 @@ resource "google_sql_database_instance" "google_sql_database_instance-module-rea
   count      = "${var.instance_read_only_replica_count}"
   depends_on = ["google_sql_database_instance.google_sql_database_instance-module-master"]
 }
-
-module "cabify_prometheus_mysql_scraper" {
-  source               = "git@github.com:cabify/terraform-modules.git//google-cloud/kubernetes/prometheus-mysql-scraper?ref=google-cloud_kubernetes-prometheus-mysql-scraper-v0.1.4"
-  service_name         = "${var.service_name}"
-  user_name            = "${var.user_name}"
-  user_password        = "${var.user_password}"
-  instance_region      = "${var.instance_region}"
-  project              = "${var.project}"
-  service_account_file = "${var.service_account_file}"
-}


### PR DESCRIPTION
I'm having issues with the module for the prometheus scrappers used in the cloudsql module.

I'm going to remove it temporarily until @tnosaj comes back and we can do a couple of fixes. In the meantime I'll list here problems I've found. 

- The module expects that the namespace prometheus-scrappers is created.
- The module uses a service account key file. I'll change the module to use the brand new resource [google_service_account_key](https://www.terraform.io/docs/providers/google/r/google_service_account_key.html). Please note the [kubernetes example](https://www.terraform.io/docs/providers/google/r/google_service_account_key.html#example-usage-save-key-in-kubernetes-secret)