### PR TITLE
Jt/add empty configmaps

### DIFF
--- a/apps/prometheus/config-map.tf
+++ b/apps/prometheus/config-map.tf
@@ -8,8 +8,6 @@ metadata:
   name: alertrules
   namespace: prometheus
 data:
-  placeholder: /
-    empty
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -17,8 +15,6 @@ metadata:
   name: recordingrules 
   namespace: prometheus
 data:
-  placeholder: /
-    empty
 EOF
 }
 

--- a/apps/prometheus/config-map.tf
+++ b/apps/prometheus/config-map.tf
@@ -1,3 +1,27 @@
+variable "configmaps" {
+  type = "string"
+
+  default = <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertrules
+  namespace: prometheus
+data:
+  placeholder: /
+    empty
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: recordingrules 
+  namespace: prometheus
+data:
+  placeholder: /
+    empty
+EOF
+}
+
 resource "kubernetes_config_map" "prometheus-config-map" {
   metadata {
     name      = "prometheus-configuration"
@@ -5,150 +29,16 @@ resource "kubernetes_config_map" "prometheus-config-map" {
   }
 
   data {
-    prometheus.yml = <<EOF
-    global:
-      scrape_interval: 15s
-      scrape_timeout: 15s
-      evaluation_interval: 1m
+    prometheus.yml = "${file("${path.module}/files/prometheus.yaml")}"
+  }
 
-    scrape_configs:
+  // Create empty configmaps to be filled by CI
+  provisioner "local-exec" {
+    command = "cat <<EOF | kubectl create -f - ${var.configmaps}EOF"
+  }
 
-      - job_name: 'kubernetes-apiservers'
-        kubernetes_sd_configs:
-        - role: endpoints
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
-          action: keep
-          regex: default;kubernetes;https
-
-      - job_name: 'kubernetes-pods'
-        kubernetes_sd_configs:
-        - role: pod
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: kubernetes_pod_name
-      - job_name: 'kubernetes-cadvisor'
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        kubernetes_sd_configs:
-        - role: node
-        relabel_configs:
-        - action: labelmap
-          regex: __meta_kubernetes_node_label_(.+)
-        - target_label: __address__
-          replacement: kubernetes.default.svc:443
-        - source_labels: [__meta_kubernetes_node_name]
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: /api/v1/nodes/$${1}/proxy/metrics/cadvisor
-
-      - job_name: 'kubernetes-nodes'
-
-        scheme: https
-
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-        kubernetes_sd_configs:
-        - role: node
-
-        relabel_configs:
-        - action: labelmap
-          regex: __meta_kubernetes_node_label_(.+)
-        - target_label: __address__
-          replacement: kubernetes.default.svc:443
-        - source_labels: [__meta_kubernetes_node_name]
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: /api/v1/nodes/$${1}/proxy/metrics
-
-      
-      - job_name: 'kubernetes-service-endpoints'
-        
-        kubernetes_sd_configs:
-        - role: service
-
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-          action: replace
-          target_label: __scheme__
-          regex: (https?)
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-          action: replace
-          target_label: __address__
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-        - action: labelmap
-          regex: __meta_kubernetes_service_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_service_name]
-          action: replace
-          target_label: kubernetes_name
-
-      - job_name: 'kubernetes-https-service-endpoints'
-        
-        scheme: https
-        
-        kubernetes_sd_configs:
-        - role: service
-
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_https_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_https_scheme]
-          action: replace
-          target_label: __scheme__
-          regex: (https?)
-        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_https_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__meta_kubernetes_service_annotation_instance]
-          action: replace
-          target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_service_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_service_name]
-          action: replace
-          target_label: kubernetes_name
-    EOF
+  provisioner "local-exec" {
+    command = "cat <<EOF | kubectl delete -f - ${var.configmaps}EOF"
+    when    = "destroy"
   }
 }

--- a/apps/prometheus/files/prometheus.yaml
+++ b/apps/prometheus/files/prometheus.yaml
@@ -1,0 +1,143 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 15s
+  evaluation_interval: 1m
+
+scrape_configs:
+
+  - job_name: 'kubernetes-apiservers'
+    kubernetes_sd_configs:
+    - role: endpoints
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+      action: keep
+      regex: default;kubernetes;https
+
+  - job_name: 'kubernetes-pods'
+    kubernetes_sd_configs:
+    - role: pod
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+      target_label: __address__
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_(.+)
+    - source_labels: [__meta_kubernetes_namespace]
+      action: replace
+      target_label: kubernetes_namespace
+    - source_labels: [__meta_kubernetes_pod_name]
+      action: replace
+      target_label: kubernetes_pod_name
+  - job_name: 'kubernetes-cadvisor'
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+    - role: node
+    relabel_configs:
+    - action: labelmap
+      regex: __meta_kubernetes_node_label_(.+)
+    - target_label: __address__
+      replacement: kubernetes.default.svc:443
+    - source_labels: [__meta_kubernetes_node_name]
+      regex: (.+)
+      target_label: __metrics_path__
+      replacement: /api/v1/nodes/$${1}/proxy/metrics/cadvisor
+
+  - job_name: 'kubernetes-nodes'
+
+    scheme: https
+
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    kubernetes_sd_configs:
+    - role: node
+
+    relabel_configs:
+    - action: labelmap
+      regex: __meta_kubernetes_node_label_(.+)
+    - target_label: __address__
+      replacement: kubernetes.default.svc:443
+    - source_labels: [__meta_kubernetes_node_name]
+      regex: (.+)
+      target_label: __metrics_path__
+      replacement: /api/v1/nodes/$${1}/proxy/metrics
+
+  
+  - job_name: 'kubernetes-service-endpoints'
+    
+    kubernetes_sd_configs:
+    - role: service
+
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: replace
+      target_label: __scheme__
+      regex: (https?)
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      action: replace
+      target_label: __address__
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+    - action: labelmap
+      regex: __meta_kubernetes_service_label_(.+)
+    - source_labels: [__meta_kubernetes_namespace]
+      action: replace
+      target_label: kubernetes_namespace
+    - source_labels: [__meta_kubernetes_service_name]
+      action: replace
+      target_label: kubernetes_name
+
+  - job_name: 'kubernetes-https-service-endpoints'
+    
+    scheme: https
+    
+    kubernetes_sd_configs:
+    - role: service
+
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_https_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_https_scheme]
+      action: replace
+      target_label: __scheme__
+      regex: (https?)
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_https_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__meta_kubernetes_service_annotation_instance]
+      action: replace
+      target_label: __address__
+    - action: labelmap
+      regex: __meta_kubernetes_service_label_(.+)
+    - source_labels: [__meta_kubernetes_namespace]
+      action: replace
+      target_label: kubernetes_namespace
+    - source_labels: [__meta_kubernetes_service_name]
+      action: replace
+      target_label: kubernetes_name

--- a/apps/prometheus/files/prometheus.yaml
+++ b/apps/prometheus/files/prometheus.yaml
@@ -3,6 +3,10 @@ global:
   scrape_timeout: 15s
   evaluation_interval: 1m
 
+rule_files:
+    - /etc/prometheus/alerts/*.yml
+    - /etc/prometheus/recordings/*.yml
+
 scrape_configs:
 
   - job_name: 'kubernetes-apiservers'

--- a/apps/prometheus/replication-controller.tf
+++ b/apps/prometheus/replication-controller.tf
@@ -43,6 +43,24 @@ resource "kubernetes_replication_controller" "prometheus" {
       }
 
       volume {
+        name = "prometheus-alertrules-volume"
+
+        config_map {
+          name         = "alertrules"
+          default_mode = 420
+        }
+      }
+
+      volume {
+        name = "prometheus-recordingrules-volume"
+
+        config_map {
+          name         = "recordingrules"
+          default_mode = 420
+        }
+      }
+
+      volume {
         name = "prometheus-storage-volume"
 
         persistent_volume_claim {
@@ -56,7 +74,17 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         volume_mount {
           name       = "prometheus-config-volume"
-          mount_path = "/etc/prometheus/"
+          mount_path = "/etc/prometheus/config/"
+        }
+
+        volume_mount {
+          name       = "prometheus-alertrules-volume"
+          mount_path = "/etc/prometheus/alerts/"
+        }
+
+        volume_mount {
+          name       = "prometheus-recordingrules-volume"
+          mount_path = "/etc/prometheus/recordings/"
         }
 
         args = ["-v", "-t", "-p=/etc/prometheus", "curl", "-X", "POST", "--fail", "-o", "-", "-sS", "http://localhost:${var.prometheus-port}/-/reload"]
@@ -77,7 +105,17 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         volume_mount {
           name       = "prometheus-config-volume"
-          mount_path = "/etc/prometheus/"
+          mount_path = "/etc/prometheus/config/"
+        }
+
+        volume_mount {
+          name       = "prometheus-alertrules-volume"
+          mount_path = "/etc/prometheus/alerts/"
+        }
+
+        volume_mount {
+          name       = "prometheus-recordingrules-volume"
+          mount_path = "/etc/prometheus/recordings/"
         }
 
         volume_mount {
@@ -85,7 +123,7 @@ resource "kubernetes_replication_controller" "prometheus" {
           mount_path = "/prometheus/"
         }
 
-        args = ["--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus/", "--web.enable-lifecycle"]
+        args = ["--config.file=/etc/prometheus/config/prometheus.yml", "--storage.tsdb.path=/prometheus/", "--web.enable-lifecycle"]
 
         liveness_probe {
           http_get {


### PR DESCRIPTION
This creates 2 empty configmaps NOT tracked by terraform, but necessary for container start. The config maps are filled by the CI [here](https://gitlab.otters.xyz/product/systems/prometheus/prometheus-config/merge_requests/2)

The restart sidecar now watches all of `/etc/prometheus` recursively and reloads configs.
