### PR TITLE
oauth2_proxy: remove Service Account

### DIFF
--- a/google-cloud/kubernetes/oauth2-proxy/oauth2_proxy_secrets.tf
+++ b/google-cloud/kubernetes/oauth2-proxy/oauth2_proxy_secrets.tf
@@ -1,15 +1,3 @@
-# This secret contains the service account necessary for Oauth2 Proxy
-resource "kubernetes_secret" "oauth2_proxy_credential" {
-  metadata {
-    name      = "oauth2-proxy-credential"
-    namespace = "${var.oauth2_proxy_deployment_namespace}"
-  }
-
-  data {
-    credentials.json = "${base64decode(google_service_account_key.oauth2_proxy_service_account_key.private_key)}"
-  }
-}
-
 # This secret contains Google API OAuth credentials for Oauth2 Proxy.
 resource "kubernetes_secret" "oauth2_proxy_api_oauth_credentials" {
   metadata {


### PR DESCRIPTION
It was a PoC and it's not being used, we don't need a specific GCP service account for `oauth2_proxy`.