### PR TITLE
[ingress-nginx] update nginx-ingress-controller to 0.18.0

### DIFF
--- a/google-cloud/kubernetes/ingress-nginx/12_mandatory_deployment_ingress_nginx.yaml
+++ b/google-cloud/kubernetes/ingress-nginx/12_mandatory_deployment_ingress_nginx.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.17.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.18.0
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/google-cloud/kubernetes/ingress-nginx/ChangeLog.md
+++ b/google-cloud/kubernetes/ingress-nginx/ChangeLog.md
@@ -1,0 +1,5 @@
+# ChangeLog
+
+### 0.1.2
+
+- Update `nginx-ingress-controller` to 0.18.0


### PR DESCRIPTION
This updates `nginx-ingress-controller` to v0.18.0, upstream's ChangeLog:

https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0180