### PR TITLE
Upgrade prometheus to 2.5.0 and add parameter to set log-level

### DIFF
--- a/apps/prometheus/inputs.tf
+++ b/apps/prometheus/inputs.tf
@@ -50,6 +50,12 @@ variable "external_url" {
   type        = "string"
 }
 
+variable "log_level" {
+  description = "Log level for the instance. Defaults to info."
+  type        = "string"
+  default     = "info"
+}
+
 variable "prometheus_io_scrape" {
   description = "Set it to your desired value to get prometheus scraped. By default it will be true"
   type        = "string"

--- a/apps/prometheus/replication-controller.tf
+++ b/apps/prometheus/replication-controller.tf
@@ -95,7 +95,7 @@ resource "kubernetes_replication_controller" "prometheus" {
       }
 
       container {
-        image = "prom/prometheus:v2.3.2"
+        image = "prom/prometheus:v2.5.0"
         name  = "prometheus"
 
         port {
@@ -132,6 +132,7 @@ resource "kubernetes_replication_controller" "prometheus" {
           "--storage.tsdb.path=/prometheus/",
           "--web.enable-lifecycle",
           "--web.external-url=${var.external_url}",
+          "--log.level=${var.log_level}"
         ]
 
         liveness_probe {

--- a/apps/prometheus/replication-controller.tf
+++ b/apps/prometheus/replication-controller.tf
@@ -132,7 +132,7 @@ resource "kubernetes_replication_controller" "prometheus" {
           "--storage.tsdb.path=/prometheus/",
           "--web.enable-lifecycle",
           "--web.external-url=${var.external_url}",
-          "--log.level=${var.log_level}"
+          "--log.level=${var.log_level}",
         ]
 
         liveness_probe {


### PR DESCRIPTION
This PR upgrades the image used for the prometheus replication controllers to 2.5.0, and also adds an optional parameter to set log-level (useful when we have problems, and always nicer than having to edit the rc with kubectl).