### PR TITLE
Allow custom stackdriver scrapper image

### DIFF
--- a/google-cloud/kubernetes/prometheus-elasticsearch-scraper/service.tf
+++ b/google-cloud/kubernetes/prometheus-elasticsearch-scraper/service.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_service" "elasticsearch" {
   metadata {
     annotations {
-      prometheus_io_scrape = "persistence"
+      prometheus_io_scrape      = "persistence"
       prometheus_io_environment = "${var.environment}"
     }
 

--- a/google-cloud/kubernetes/prometheus-mysql-scraper/inputs.tf
+++ b/google-cloud/kubernetes/prometheus-mysql-scraper/inputs.tf
@@ -37,4 +37,3 @@ variable "tier" {
   description = "Name of tier (1.2.3)"
   type        = "string"
 }
-

--- a/google-cloud/kubernetes/prometheus-mysql-scraper/service.tf
+++ b/google-cloud/kubernetes/prometheus-mysql-scraper/service.tf
@@ -1,11 +1,11 @@
 resource "kubernetes_service" "cloudsql" {
   metadata {
     annotations {
-      prometheus_io_scrape = "persistence"
+      prometheus_io_scrape      = "persistence"
       prometheus_io_environment = "${replace(var.project,"cabify-","")}"
-      prometheus_io_service = "${var.service_name}"
-      prometheus_io_ownder = "${var.owner}"
-      prometheus_io_tier = "${var.tier}"
+      prometheus_io_service     = "${var.service_name}"
+      prometheus_io_ownder      = "${var.owner}"
+      prometheus_io_tier        = "${var.tier}"
     }
 
     name      = "${kubernetes_replication_controller.cloudsql.metadata.0.name}"

--- a/google-cloud/kubernetes/prometheus-redis-scraper/inputs.tf
+++ b/google-cloud/kubernetes/prometheus-redis-scraper/inputs.tf
@@ -47,4 +47,3 @@ variable "tier" {
   description = "Name of tier (1.2.3)"
   type        = "string"
 }
-

--- a/google-cloud/kubernetes/prometheus-redis-scraper/service.tf
+++ b/google-cloud/kubernetes/prometheus-redis-scraper/service.tf
@@ -1,11 +1,11 @@
 resource "kubernetes_service" "redis" {
   metadata {
     annotations {
-      prometheus_io_scrape = "persistence"
+      prometheus_io_scrape      = "persistence"
       prometheus_io_environment = "${replace(var.project,"cabify-","")}"
-      prometheus_io_service = "${var.service}"
-      prometheus_io_ownder = "${var.owner}"
-      prometheus_io_tier = "${var.tier}"
+      prometheus_io_service     = "${var.service}"
+      prometheus_io_ownder      = "${var.owner}"
+      prometheus_io_tier        = "${var.tier}"
     }
 
     name      = "${kubernetes_replication_controller.redis.metadata.0.name}"

--- a/google-cloud/kubernetes/prometheus-stackdriver-scraper/README.md
+++ b/google-cloud/kubernetes/prometheus-stackdriver-scraper/README.md
@@ -33,3 +33,15 @@ module "cabify_google_cloud_sql_stackdriver_scraper" {
 
 ### project
 **Description:** "Name of the gcp project"
+
+### namespace
+**Description:** "Name of the Kubernetes namespace where the scrapper will run"
+
+### image-name
+**Description:** "Name for the stackdriver container image to run"
+
+### image-tag
+**Description:** "Tag for the stackdriver container image to run"
+
+### environment
+**Description:** "Name of the environment - will be used to annotate the resource"

--- a/google-cloud/kubernetes/prometheus-stackdriver-scraper/inputs.tf
+++ b/google-cloud/kubernetes/prometheus-stackdriver-scraper/inputs.tf
@@ -19,6 +19,12 @@ variable "namespace" {
   default     = "prometheus"
 }
 
+variable "image-name" {
+  description = "Name for the stackdriver container image"
+  type        = "string"
+  default     = "frodenas/stackdriver-exporter"
+}
+
 variable "image-tag" {
   description = "Tag for the stackdriver container image"
   type        = "string"

--- a/google-cloud/kubernetes/prometheus-stackdriver-scraper/replication-controller.tf
+++ b/google-cloud/kubernetes/prometheus-stackdriver-scraper/replication-controller.tf
@@ -28,7 +28,7 @@ resource "kubernetes_replication_controller" "stackdriver" {
       }
 
       container {
-        image = "frodenas/stackdriver-exporter:${var.image-tag}"
+        image = "${var.image-name}:${var.image-tag}"
         name  = "${var.service}-${replace(var.project,"cabify-","")}-stackdriver-exporter"
 
         port {

--- a/google-cloud/kubernetes/prometheus-stackdriver-scraper/service.tf
+++ b/google-cloud/kubernetes/prometheus-stackdriver-scraper/service.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_service" "stackdriver" {
   metadata {
     annotations {
-      prometheus_io_scrape = "persistence"
+      prometheus_io_scrape      = "persistence"
       prometheus_io_environment = "${var.environment}"
     }
 


### PR DESCRIPTION
Added a config variable to allow customizing the Docker image to run. This allows using forks of the StackDriver scrapper and not only the official image.
