### PR TITLE
Make default mode for volumes be octal numerals

### DIFF
--- a/apps/prometheus/replication-controller.tf
+++ b/apps/prometheus/replication-controller.tf
@@ -33,7 +33,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         secret {
           secret_name  = "${kubernetes_service_account.prometheus.default_secret_name}"
-          default_mode = 0420
+          default_mode = 420
         }
       }
 
@@ -42,7 +42,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         config_map {
           name         = "${kubernetes_config_map.prometheus.metadata.0.name}"
-          default_mode = 0420
+          default_mode = 420
         }
       }
 
@@ -51,7 +51,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         config_map {
           name         = "alertrules"
-          default_mode = 0420
+          default_mode = 420
         }
       }
 
@@ -60,7 +60,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         config_map {
           name         = "recordingrules"
-          default_mode = 0420
+          default_mode = 420
         }
       }
 

--- a/apps/prometheus/replication-controller.tf
+++ b/apps/prometheus/replication-controller.tf
@@ -33,7 +33,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         secret {
           secret_name  = "${kubernetes_service_account.prometheus.default_secret_name}"
-          default_mode = 420
+          default_mode = 0420
         }
       }
 
@@ -42,7 +42,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         config_map {
           name         = "${kubernetes_config_map.prometheus.metadata.0.name}"
-          default_mode = 420
+          default_mode = 0420
         }
       }
 
@@ -51,7 +51,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         config_map {
           name         = "alertrules"
-          default_mode = 420
+          default_mode = 0420
         }
       }
 
@@ -60,7 +60,7 @@ resource "kubernetes_replication_controller" "prometheus" {
 
         config_map {
           name         = "recordingrules"
-          default_mode = 420
+          default_mode = 0420
         }
       }
 
@@ -157,14 +157,16 @@ resource "kubernetes_replication_controller" "prometheus" {
           period_seconds        = "${var.livenessprobe_period_seconds}"
           timeout_seconds       = "${var.livenessprobe_timeout_seconds}"
         }
+
         readiness_probe {
           http_get {
             path = "/-/ready"
             port = "${var.prometheus-port}"
           }
-          period_seconds        = "${var.readinessprobe_period_seconds}"
-          timeout_seconds       = "${var.readinessprobe_timeout_seconds}"
-         }
+
+          period_seconds  = "${var.readinessprobe_period_seconds}"
+          timeout_seconds = "${var.readinessprobe_timeout_seconds}"
+        }
       }
     }
   }


### PR DESCRIPTION
An upgrade in the terraform kubernetes provider forces us to patch this version so that default modes are in octal format.

https://github.com/terraform-providers/terraform-provider-kubernetes/blob/4fa027153cf647b2679040b6c4653ef24e34f816/kubernetes/validators.go#L203-L206

Related to: 
- https://github.com/terraform-providers/terraform-provider-kubernetes/pull/351

**Note: This module is going to get removed since we're no longer managing prometheus with terraform. The patch is only to support a legacy instance that soon will be migrated**.

cc @jihonrado 