### PR TITLE
Update doc with new google oauth image

### DIFF
--- a/google-cloud/kubernetes/oauth2-proxy/README.md
+++ b/google-cloud/kubernetes/oauth2-proxy/README.md
@@ -72,7 +72,7 @@ http://grafana.otters.xyz/auth/login/google/authorize
 
 ### oauth2_proxy_deployment_image
 **Description:** "The docker image for the oauth2-proxy. Format should be like
-`cabify/oauth2_proxy:latest`"
+`quay.io/pusher/oauth2_proxy:v3.2.0`"
 
 ### oauth2_proxy_deployment_email_domain
 **Description:** "The allowed email domain used for oauth. E.g. `cabify.com`"


### PR DESCRIPTION
Updating docs with new oauth image. We are moving out from Dockerhub: https://gitlab.otters.xyz/infrastructure/application-runtime/issues/404

Since there is no code change I believe we do not need to bump the module version.