### PR TITLE
Using latest it was bumped to 1.1.0 and ports changed. 

### DIFF
--- a/google-cloud/kubernetes/prometheus-elasticsearch-scraper/replication-controller.tf
+++ b/google-cloud/kubernetes/prometheus-elasticsearch-scraper/replication-controller.tf
@@ -32,7 +32,7 @@ resource "kubernetes_replication_controller" "elasticsearch" {
           }
         }
 
-        image = "justwatch/elasticsearch_exporter:latest"
+        image = "justwatch/elasticsearch_exporter:1.0.2"
         name  = "${replace(var.project,"cabify-","")}-elasticsearch-exporter"
 
         port {


### PR DESCRIPTION
Binding image back to `1.0.2`, using latest it bumped to `1.1.0` and there is a port change on this version. Pods were in crashloopback
