### PR TITLE
[please do not merge to master] Comment out myslq_scraper for movo and bive

### DIFF
--- a/google-cloud/sql/main.tf
+++ b/google-cloud/sql/main.tf
@@ -74,20 +74,18 @@ resource "google_sql_database_instance" "google_sql_database_instance-module-rea
   depends_on = [google_sql_database_instance.google_sql_database_instance-module-master]
 }
 
-module "cabify_prometheus_mysql_scraper" {
-  // This is for movo only - until they get a monitoring cluster
-  count = 0
-
-  source                           = "git@github.com:cabify/terraform-modules.git//google-cloud/kubernetes/prometheus-mysql-scraper?ref=google-cloud_kubernetes-prometheus-mysql-scraper-v0.1.18"
-  service_name                     = var.service_name
-  user_name                        = var.user_name
-  user_password                    = var.user_password
-  instance_region                  = var.instance_region
-  project                          = var.project
-  namespace                        = var.namespace
-  owner                            = var.owner
-  tier                             = var.tier
-  instance_read_only_replica_count = var.instance_read_only_replica_count
-  instance_tier                    = var.instance_tier
-  instance_tier_read_only_replica  = var.instance_tier_read_only_replica
-}
+// This is for movo/bive only - until they get a monitoring cluster
+// module "cabify_prometheus_mysql_scraper" {
+//  source                           = "git@github.com:cabify/terraform-modules.git//google-cloud/kubernetes/prometheus-mysql-scraper?ref=google-cloud_kubernetes-prometheus-mysql-scraper-v0.1.18"
+//  service_name                     = var.service_name
+//  user_name                        = var.user_name
+//  user_password                    = var.user_password
+//  instance_region                  = var.instance_region
+//  project                          = var.project
+//  namespace                        = var.namespace
+//  owner                            = var.owner
+//  tier                             = var.tier
+//  instance_read_only_replica_count = var.instance_read_only_replica_count
+//  instance_tier                    = var.instance_tier
+//  instance_tier_read_only_replica  = var.instance_tier_read_only_replica
+//}


### PR DESCRIPTION
I tried to use `google-cloud_sql-v0.1.27-movo` tag and then
```
Error: Reserved argument name in module block

  on .terraform/modules/google_cloud_sql_mysql_gregario/google-cloud/sql/main.tf line 79, in module "cabify_prometheus_mysql_scraper":
  79:   count = 0

The name "count" is reserved for use in a future version of Terraform.
```
So I'm commeting out myslq_scraper enterily.

https://www.terraform.io/docs/configuration/variables.html#declaring-an-input-variable

⚠️ I'm opening the MR to give visibility but it shouldn't be merged to master branch ⚠️ 

I'm gonna tag again this commit with `google-cloud_sql-v0.1.27-movo`

cc @tnosaj 