### PR TITLE
Drop engine parameters on rds replica

### DIFF
--- a/aws/rds/rds_instance.tf
+++ b/aws/rds/rds_instance.tf
@@ -72,8 +72,6 @@ resource "aws_db_instance" "read-replica" {
   publicly_accessible    = var.public_access
 
   // mysql specific
-  engine                      = var.engine_name
-  engine_version              = var.engine_version
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = var.tier == "3" ? true : false
   parameter_group_name        = aws_db_parameter_group.rds.id


### PR DESCRIPTION
## Problem

The latest update of the AWS provider makes the `engine` parameters unusable if `replicate_source_db` is specified.

See:
- [instance.go#L195](https://github.com/hashicorp/terraform-provider-aws/blob/7875c870ca0cc382ba6ca17e98bbf9727bf158f7/internal/service/rds/instance.go#L195)
- [upstream change](https://github.com/hashicorp/terraform-provider-aws/commit/82717f66617174f73178ec5c16764bbf4251826d)
- [our broken pipeline](https://gitlab.otters.xyz/infrastructure/persistence/terraform/aws/cabify-softest-layer-tier-1/-/jobs/7307144#L2299)

## Solution

Remove the parameters as per [documentation](https://github.com/hashicorp/terraform-provider-aws/commit/82717f66617174f73178ec5c16764bbf4251826d#diff-6a5091b97b3df2ae806bf12492d9c100f0f72d90527d0cd45f540bd2043d906eR113).

---

cc @dinapappor 
