### PR TITLE
Deploy latest image of watch

### DIFF
--- a/aws/rds/exporter_sql_deployment.tf
+++ b/aws/rds/exporter_sql_deployment.tf
@@ -96,7 +96,7 @@ resource "kubernetes_deployment" "sql_exporter" {
             }
           }
 
-          image = "us.gcr.io/cabify-controlpanel/infrastructure/monitoring/dockerfiles/watch/watch:master-5fc29a9"
+          image = "us.gcr.io/cabify-controlpanel/infrastructure/monitoring/dockerfiles/watch/watch"
           name  = "sql-exporter-config-watcher"
 
           args = [


### PR DESCRIPTION
## Problem

The watch image we are using in the exporter deployments is out of date.

## Solution

I have removed the tag so the image referenced is latest (we keep the image updated automatically in the origin repo)
---

cc Ping somebody here for review!
