### PR TITLE
Revert "Drop engine parameters on rds replica"

### DIFF
--- a/aws/rds/rds_instance.tf
+++ b/aws/rds/rds_instance.tf
@@ -72,6 +72,8 @@ resource "aws_db_instance" "read-replica" {
   publicly_accessible    = var.public_access
 
   // mysql specific
+  engine                      = var.engine_name
+  engine_version              = var.engine_version
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = var.tier == "3" ? true : false
   parameter_group_name        = aws_db_parameter_group.rds.id


### PR DESCRIPTION
Reverts cabify/terraform-modules#112

It seems we need those parameters on terraform aws provider version <4.0. Also we cannot upgrade to a version greater than 4.0 because how it manages the version of the replicas.