### PR TITLE
Allow RDS replicas to have different version than master

### DIFF
--- a/aws/rds/input.tf
+++ b/aws/rds/input.tf
@@ -180,6 +180,12 @@ variable "read_only_replica_instance_class" {
   default     = "UNSET"
 }
 
+variable "read_only_replica_engine_version" {
+  description = "Engine version of the database replicas to be launched"
+  type        = string
+  default     = "UNSET"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS: Monitoring
 # These parameters have reasonable defaults.

--- a/aws/rds/rds_instance.tf
+++ b/aws/rds/rds_instance.tf
@@ -73,7 +73,7 @@ resource "aws_db_instance" "read-replica" {
 
   // mysql specific
   engine                      = var.engine_name
-  engine_version              = var.engine_version
+  engine_version              = var.read_only_replica_engine_version == "UNSET" ? var.replicas_engine_version : var.read_only_replica_engine_version
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = var.tier == "3" ? true : false
   parameter_group_name        = aws_db_parameter_group.rds.id


### PR DESCRIPTION
## Problem

For upgrading databases with RO replicas we need to be able to upgrade first the replicas and then the master, so we need a way to configure rds `engine_version` parameter for master and for replicas.

## Solution

I've added a new optional parameter `read_only_replica_engine_version`. If present it configures the replica `engine_version` parameter.

---