### PR TITLE
Add spot scheduling capability

### DIFF
--- a/aws/rds/exporter_cloudwatch_deployment.tf
+++ b/aws/rds/exporter_cloudwatch_deployment.tf
@@ -40,6 +40,18 @@ resource "kubernetes_deployment" "cloudwatch" {
         automount_service_account_token = false
         enable_service_links            = true
 
+        # For allowing spot scheduling
+        node_selector = var.spot_scheduling ? { "node.kubernetes.io/lifecycle" = "spot" } : {}
+        dynamic "toleration" {
+          for_each = var.spot_scheduling ? [1] : []
+          content {
+            effect = "NoSchedule"
+            key =  "spot"
+            operator = "Equal"
+            value = "true"
+          }
+        }
+
         container {
           resources {
             limits = {
@@ -180,6 +192,18 @@ resource "kubernetes_deployment" "cloudwatch-read-only" {
         restart_policy                  = "Always"
         automount_service_account_token = false
         enable_service_links            = true
+
+        # For allowing spot scheduling
+        node_selector = var.spot_scheduling ? { "node.kubernetes.io/lifecycle" = "spot" } : {}
+        dynamic "toleration" {
+          for_each = var.spot_scheduling ? [1] : []
+          content {
+            effect = "NoSchedule"
+            key =  "spot"
+            operator = "Equal"
+            value = "true"
+          }
+        }
 
         container {
           resources {

--- a/aws/rds/exporter_cloudwatch_enhanced_deployment.tf
+++ b/aws/rds/exporter_cloudwatch_enhanced_deployment.tf
@@ -42,6 +42,18 @@ resource "kubernetes_deployment" "cloudwatch-enhanced" {
         automount_service_account_token = false
         enable_service_links            = true
 
+        # For allowing spot scheduling
+        node_selector = var.spot_scheduling ? { "node.kubernetes.io/lifecycle" = "spot" } : {}
+        dynamic "toleration" {
+          for_each = var.spot_scheduling ? [1] : []
+          content {
+            effect = "NoSchedule"
+            key =  "spot"
+            operator = "Equal"
+            value = "true"
+          }
+        }
+
         container {
           resources {
             limits = {
@@ -182,6 +194,18 @@ resource "kubernetes_deployment" "cloudwatch-read-only-enhanced" {
         restart_policy                  = "Always"
         automount_service_account_token = false
         enable_service_links            = true
+
+        # For allowing spot scheduling
+        node_selector = var.spot_scheduling ? { "node.kubernetes.io/lifecycle" = "spot" } : {}
+        dynamic "toleration" {
+          for_each = var.spot_scheduling ? [1] : []
+          content {
+            effect = "NoSchedule"
+            key =  "spot"
+            operator = "Equal"
+            value = "true"
+          }
+        }
 
         container {
           resources {

--- a/aws/rds/exporter_deployment.tf
+++ b/aws/rds/exporter_deployment.tf
@@ -39,6 +39,18 @@ resource "kubernetes_deployment" "rds" {
         automount_service_account_token = false
         enable_service_links            = true
 
+        # For allowing spot scheduling
+        node_selector = var.spot_scheduling ? { "node.kubernetes.io/lifecycle" = "spot" } : {}
+        dynamic "toleration" {
+          for_each = var.spot_scheduling ? [1] : []
+          content {
+            effect = "NoSchedule"
+            key =  "spot"
+            operator = "Equal"
+            value = "true"
+          }
+        }
+
         container {
           resources {
             limits = {
@@ -150,6 +162,18 @@ resource "kubernetes_deployment" "rds-read-only" {
         restart_policy                  = "Always"
         automount_service_account_token = false
         enable_service_links            = true
+
+        # For allowing spot scheduling
+        node_selector = var.spot_scheduling ? { "node.kubernetes.io/lifecycle" = "spot" } : {}
+        dynamic "toleration" {
+          for_each = var.spot_scheduling ? [1] : []
+          content {
+            effect = "NoSchedule"
+            key =  "spot"
+            operator = "Equal"
+            value = "true"
+          }
+        }
 
         container {
           resources {

--- a/aws/rds/exporter_sql_deployment.tf
+++ b/aws/rds/exporter_sql_deployment.tf
@@ -40,6 +40,18 @@ resource "kubernetes_deployment" "sql_exporter" {
         automount_service_account_token = false
         enable_service_links            = true
 
+        # For allowing spot scheduling
+        node_selector = var.spot_scheduling ? { "node.kubernetes.io/lifecycle" = "spot" } : {}
+        dynamic "toleration" {
+          for_each = var.spot_scheduling ? [1] : []
+          content {
+            effect = "NoSchedule"
+            key =  "spot"
+            operator = "Equal"
+            value = "true"
+          }
+        }
+
         container {
           resources {
             limits = {

--- a/aws/rds/input.tf
+++ b/aws/rds/input.tf
@@ -129,6 +129,12 @@ variable "port" {
   default     = 3306
 }
 
+variable "spot_scheduling" {
+  description = "Scheduling exporters in spot instances"
+  type        = bool
+  default     = false
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS: GCP migration
 # These parameters have reasonable defaults.


### PR DESCRIPTION
## Problem

Allow the RDS exporters to deploy on spot instances depending on a condition.

## Solution

I've created a new input variable (defaulting to false) and from that I generate the tolerations needed for scheduling on spots.