### PR TITLE
Added backup restoration capability

### DIFF
--- a/aws/rds/input.tf
+++ b/aws/rds/input.tf
@@ -360,6 +360,20 @@ variable "maintenance_window" {
   default     = "mon:10:00-mon:11:00"
 }
 
+#
+# Restore backups
+#
+variable "restore_origin_db_identifier" {
+  type        = string
+  description = "ARN for the source DB to restore"
+  default     = "UNSET"
+}
+
+variable "restore_point_in_time" {
+  type        = string
+  description = "Exact data for the PIT recover"
+  default     = "UNSET"
+}
 
 ###
 # testing only

--- a/aws/rds/input.tf
+++ b/aws/rds/input.tf
@@ -371,7 +371,7 @@ variable "restore_origin_db_identifier" {
 
 variable "restore_point_in_time" {
   type        = string
-  description = "Exact data for the PIT recover"
+  description = "Exact date for the PIT recover"
   default     = "UNSET"
 }
 

--- a/aws/rds/rds_instance.tf
+++ b/aws/rds/rds_instance.tf
@@ -50,6 +50,9 @@ resource "aws_db_instance" "primary" {
   // performance_insights_retention_period = 7
 
   // Restore from backup - The block will only appear if var.restore_origin_db_identifier is different than "UNSET"
+  lifecycle {
+    ignore_changes = [restore_to_point_in_time]
+  }
   dynamic "restore_to_point_in_time" {
     for_each = var.restore_origin_db_identifier != "UNSET" ? [1] : []
     content {

--- a/aws/rds/rds_instance.tf
+++ b/aws/rds/rds_instance.tf
@@ -51,13 +51,12 @@ resource "aws_db_instance" "primary" {
 
   // Restore from backup - The block will only appear if var.restore_origin_db_identifier is different than "UNSET"
   dynamic "restore_to_point_in_time" {
-    for_each = source_db_instance_identifier != "UNSET" ? [1] : []
+    for_each = var.restore_origin_db_identifier != "UNSET" ? [1] : []
     content {
       source_db_instance_identifier = var.restore_origin_db_identifier
       restore_time = var.restore_point_in_time
     }
   }
-
 
 }
 

--- a/aws/rds/rds_instance.tf
+++ b/aws/rds/rds_instance.tf
@@ -48,6 +48,17 @@ resource "aws_db_instance" "primary" {
   monitoring_role_arn          = "arn:aws:iam::${var.aws_account_nr}:role/rds-monitoring-role"
   performance_insights_enabled = var.tier == "3" ? false : true
   // performance_insights_retention_period = 7
+
+  // Restore from backup - The block will only appear if var.restore_origin_db_identifier is different than "UNSET"
+  dynamic "restore_to_point_in_time" {
+    for_each = source_db_instance_identifier != "UNSET" ? [1] : []
+    content {
+      source_db_instance_identifier = var.restore_origin_db_identifier
+      restore_time = var.restore_point_in_time
+    }
+  }
+
+
 }
 
 resource "aws_db_instance" "read-replica" {


### PR DESCRIPTION
## Gitlab [issue](https://gitlab.otters.xyz/infrastructure/persistence/lobby/-/issues/728)

## Problem

We are investigating a way to do (semi)automatic database restore from backup. If some disaster arise, we want a way to quickly setup a new DB with the state of the original DB.

## Solution

I am adding some parameters to the rds module for allowing to specify a DB origin and Point In Time Restoration time. If not present, the module will behave as previously. If present, it will instantiate a new DB with the state of the original DB in the PIT required.

Since changes on the source DB or time will replace the RDS DB instance, the module will ignore changes on those parameters (IE they can only be specified on DB creation).
---
