### PR TITLE
Fix name of DB when restoring

### DIFF
--- a/aws/rds/mysql_db.tf
+++ b/aws/rds/mysql_db.tf
@@ -1,7 +1,7 @@
 # Create a second database, in addition to the "initial_db" created
 # by the aws_db_instance resource above.
 resource "mysql_database" "appdb" {
-  name = var.instance_name
+  name = var.restore_origin_db_identifier != "UNSET" ? var.restore_origin_db_identifier : var.instance_name
   default_character_set = "utf8mb4"
   default_collation = "utf8mb4_general_ci"
 }


### PR DESCRIPTION
## Gitlab [issue](https://gitlab.otters.xyz/infrastructure/persistence/lobby/-/issues/728)

## Problem

When we restore an RDS instance the DB name is no longer the same as the instance name.

## Solution

In case of resotoring the DB from a backup, the DB name should be the restored DB name, not the instance name.

