### PR TITLE
add some parameters for replicas

### DIFF
--- a/aws/rds/input.tf
+++ b/aws/rds/input.tf
@@ -366,6 +366,12 @@ variable "maintenance_window" {
   default     = "mon:10:00-mon:11:00"
 }
 
+variable "maintenance_replica_window" {
+  type        = string
+  description = "The window to perform maintenance in replicas. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC "
+  default     = "UNSET"
+}
+
 #
 # Restore backups
 #

--- a/aws/rds/rds_instance.tf
+++ b/aws/rds/rds_instance.tf
@@ -68,7 +68,7 @@ resource "aws_db_instance" "read-replica" {
 
   identifier          = "${var.instance_name}-read-replica-${count.index + 1}"
   apply_immediately   = var.apply_immediately
-  maintenance_window  = var.maintenance_window
+  maintenance_window  = var.maintenance_replica_window == "UNSET" ? var.maintenance_window : var.maintenance_replica_window
   skip_final_snapshot = true
   license_model       = var.license_model
   // general
@@ -88,7 +88,7 @@ resource "aws_db_instance" "read-replica" {
   engine                      = var.engine_name
   engine_version              = var.read_only_replica_engine_version == "UNSET" ? var.engine_version : var.read_only_replica_engine_version
   allow_major_version_upgrade = false
-  auto_minor_version_upgrade  = var.tier == "3" ? true : false
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
   parameter_group_name        = aws_db_parameter_group.rds.id
   option_group_name           = aws_db_option_group.rds.id
 


### PR DESCRIPTION
## https://gitlab.otters.xyz/platform/builder-tools/comms/billboard/-/issues/143#note_1578569

## Problem

From the comment in the issue, we realized that we are not setting auto_minor_upgrade parameter properly on databases on tier2 and tier1 replicas. In the case that we set the parameter to true on those databases, master and read replicas could have different versions of engine.

Also the maintenance window for both master and replicas are the same, and could be interesting to split it.

## Solution

Use var.auto_minor_upgrade for both master and replicas on all tier.
Create a new maintenance_replicas_window parameter, with `UNSET` as default. If it is not defined, use the same as the master.

---

cc @srlobo 
